### PR TITLE
Fix splash screen display condition

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,7 +29,7 @@ const RootLayoutNav = () => {
     }, [onLayoutRootView]);
 
     // Show animated splash screen until both auth loading and animation are complete
-    if (authLoading && !splashAnimationComplete) {
+    if (authLoading || !splashAnimationComplete) {
         return <AnimatedSplashScreen onAnimationFinish={handleAnimationFinish} />;
     }
 


### PR DESCRIPTION
Fix splash screen display condition to ensure it waits for both authentication and animation to complete.

The previous condition `authLoading && !splashAnimationComplete` caused the splash screen to disappear prematurely if authentication finished before the animation, leading to a jarring user experience. The updated condition `authLoading || !splashAnimationComplete` ensures the splash screen remains visible until both authentication loading and the animation are fully complete.