### PR TITLE
Fix reset password redirect loop on invalid token

### DIFF
--- a/app/(auth)/reset-password.tsx
+++ b/app/(auth)/reset-password.tsx
@@ -16,7 +16,7 @@ export default function ResetPasswordScreen() {
 
     if (typeof access_token !== 'string' || typeof refresh_token !== 'string') {
       Alert.alert('Error', 'Invalid password reset link format.');
-      router.replace('/(auth)/reset-password');
+      router.replace('/(auth)/login');
       return;
     }
 


### PR DESCRIPTION
Redirect to login from reset-password screen when tokens are invalid to prevent infinite redirect loop.